### PR TITLE
DCM-5: Hide the existing password from the UI

### DIFF
--- a/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
+++ b/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
@@ -79,11 +79,9 @@ public class DHISConnectorController {
 	public void configureServer(ModelMap model) {
 		String url = Context.getAdministrationService().getGlobalProperty(GLOBAL_PROPERTY_URL);
 		String user = Context.getAdministrationService().getGlobalProperty(GLOBAL_PROPERTY_USER);
-		String pass = Context.getAdministrationService().getGlobalProperty(GLOBAL_PROPERTY_PASS);
 
 		model.addAttribute("url", url);
 		model.addAttribute("user", user);
-		model.addAttribute("pass", pass);
 		model.addAttribute("showLogin", (Context.getAuthenticatedUser() == null) ? true : false);
 	}
 
@@ -113,7 +111,6 @@ public class DHISConnectorController {
 
 			model.addAttribute("url", url);
 			model.addAttribute("user", user);
-			model.addAttribute("pass", pass);
 		} else {
 			req.setAttribute(WebConstants.OPENMRS_ERROR_ATTR,
 					Context.getMessageSourceService().getMessage("dhisconnector.saveFailure"),

--- a/omod/src/main/webapp/configureServer.jsp
+++ b/omod/src/main/webapp/configureServer.jsp
@@ -21,7 +21,7 @@
     </tr>
     <tr>
       <td><spring:message code="dhisconnector.pass"/></td>
-      <td><input name="pass" type="password" size="20" value="${pass}"/></td>
+      <td><input name="pass" placeholder="<hidden>" type="password" size="20"/></td>
     </tr>
     <tr>
       <td/>


### PR DESCRIPTION
## The issue I worked on
See https://issues.openmrs.org/browse/DCM-5

## Description of what I changed:
Add the placeholder for the input
Remove the password value
Remove the password attribute from the backend

## Screenshot

![image](https://user-images.githubusercontent.com/43912578/99510471-21ea0d00-29ad-11eb-9bf8-9ffb9694b5b7.png)
