### PR TITLE
DCM-27: Bump httpclient and httpcore versions

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -43,13 +43,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.2.1</version>
+            <version>4.4.13</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.6</version>
+            <version>4.5.12</version>
             <type>jar</type>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
## The issue I worked on
See [https://issues.openmrs.org/browse/DCM-27](https://issues.openmrs.org/browse/DCM-27) 

## Description of what I changed:
Update `httpcore` version from 4.2.1 to 4.4.13 in `/api/pom.xml`
Update `httpclient` version from 4.3.6 to 4.5.12 in `/api/pom.xml`