### PR TITLE
DCM-24: Remove unsupported mappings from automation view

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -73,6 +73,7 @@ dhisconnector.failedData.pushAgain=Push Again
 dhisconnector.automation=Automation
 dhisconnector.automation.heading=Setting up OpenMRS reports to automatically report into the configured DHIS2 instance
 dhisconnector.automation.description=NB: Running is contextualised; the module will only run once for each day, week or month only for the previous past period respectively. Otherwise you may trigger a re-run which is likewise contextual
+dhisconnector.automation.periodTypeMessage=NOTE: Mappings with unsupported period types are disabled.
 dhisconnector.automation.toggleAutomation=Enable/Disable Automation
 dhisconnector.automation.delete=Delete
 dhisconnector.automation.run=Run

--- a/omod/src/main/webapp/automation.jsp
+++ b/omod/src/main/webapp/automation.jsp
@@ -14,6 +14,9 @@
 	<br />
 		<input type="checkbox" name="toogleAutomation" <c:if test="${automationEnabled}">checked="checked"</c:if>><spring:message code="dhisconnector.automation.toggleAutomation"/></input>
 	<br />
+    <br />
+    <spring:message code="dhisconnector.automation.periodTypeMessage"/>
+    <br />
     <table>
         <thead>
             <tr>


### PR DESCRIPTION
### The issue I worked on
See https://issues.openmrs.org/browse/DCM-24

### Description of what I changed:
Add an if condition to check the period types

I have used the period type as the name of the mapping when testing :

![image](https://user-images.githubusercontent.com/43912578/103149355-a68b3080-478e-11eb-9ca8-d255fe6ad775.png)

