### PR TITLE
Implement export DHIS mapping with metadata function

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,6 +17,11 @@
         <!-- Begin OpenMRS modules -->
         <dependency>
             <groupId>org.openmrs.module</groupId>
+            <artifactId>metadatasharing-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
             <artifactId>reporting-api</artifactId>
         </dependency>
         

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/DHISConnectorService.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/DHISConnectorService.java
@@ -11,6 +11,7 @@
  */
 package org.openmrs.module.dhisconnector.api;
 
+import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -69,7 +70,9 @@ public interface DHISConnectorService extends OpenmrsService {
 	
 	public String uploadMappings(MultipartFile mapping);
 	
-	public String[] exportSelectedMappings(String[] selectedMappings);
+	public String[] exportSelectedMappings(String[] selectedMappings) throws IOException;
+
+	public String[] exportMapping(String mapping) throws IOException;
 	
 	public boolean dhis2BackupExists();
 	

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,18 @@
         <webservicesRestVersion>2.29.0</webservicesRestVersion>
         <serializationXstreamVersion>0.2.14</serializationXstreamVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <metdatashairngVersion>1.8.0-SNAPSHOT</metdatashairngVersion>
     </properties>
 
     <dependencyManagement>
         <dependencies>
 
             <!-- Begin OpenMRS modules -->
+            <dependency>
+                <groupId>org.openmrs.module</groupId>
+                <artifactId>metadatasharing-api</artifactId>
+                <version>${metdatashairngVersion}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.openmrs.module</groupId>


### PR DESCRIPTION
### Approach
- Created a new function `exportMapping` to get the name of the mapping as a `String` and export corresponding the period indicator report with it
- Imported the metadatasharing `MetadataService` as a `Service` to get the `PeriodIndicatorReportDefinition` metadata