### PR TITLE
DCM-51: Implement share DHIS mappings with metadata feature

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -105,6 +105,17 @@
 		    <artifactId>json-simple</artifactId>
 		    <version>1.1.1</version>
 		</dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.187</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/DHISConnectorService.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/DHISConnectorService.java
@@ -12,6 +12,7 @@
 package org.openmrs.module.dhisconnector.api;
 
 import java.util.ArrayList;
+import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -73,9 +74,9 @@ public interface DHISConnectorService extends OpenmrsService {
 
 	public DHISDataSet getDHISDataSetById(String id);
 
-	public String uploadMappings(MultipartFile mapping);
-	
-	public String[] exportSelectedMappings(String[] selectedMappings);
+	public String importMappingBundle(MultipartFile mapping) throws IOException;
+
+	public String[] exportMapping(String[] mappings) throws IOException;
 	
 	public boolean dhis2BackupExists();
 	

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/db/DHISConnectorDAO.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/db/DHISConnectorDAO.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.openmrs.Location;
 import org.openmrs.module.dhisconnector.LocationToOrgUnitMapping;
+import org.openmrs.api.db.SerializedObject;
 import org.openmrs.module.dhisconnector.ReportToDataSetMapping;
 
 /**
@@ -43,4 +44,8 @@ public interface DHISConnectorDAO {
 	void saveLocationToOrgUnitMapping(LocationToOrgUnitMapping locationToOrgUnitMapping);
 
 	void deleteLocationToOrgUnitMappingsByLocation(Location location);
+
+	void saveSerializedObject(SerializedObject serializedObject);
+
+	SerializedObject getSerializedObjectByUuid(String uuid);
 }

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/db/hibernate/HibernateDHISConnectorDAO.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/db/hibernate/HibernateDHISConnectorDAO.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.Location;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.db.SerializedObject;
 import org.openmrs.api.db.hibernate.DbSessionFactory;
 import org.openmrs.module.dhisconnector.LocationToOrgUnitMapping;
 import org.openmrs.module.dhisconnector.ReportToDataSetMapping;
@@ -123,5 +124,18 @@ public class HibernateDHISConnectorDAO implements DHISConnectorDAO {
 		sessionFactory.getCurrentSession()
 				.createQuery("delete from LocationToOrgUnitMapping r where r.location = :location")
 				.setParameter("location", location).executeUpdate();
+	}
+
+	@Override
+	public void saveSerializedObject(SerializedObject serializedObject) {
+		sessionFactory.getCurrentSession().save(serializedObject);
+	}
+
+	@Override
+	public SerializedObject getSerializedObjectByUuid(String uuid) {
+		SerializedObject serializedObject = (SerializedObject) sessionFactory.getCurrentSession()
+				.createQuery("from SerializedObject s where s.uuid = :uuid")
+				.setParameter("uuid", uuid).uniqueResult();
+		return serializedObject;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/util/DHISConnectorUtil.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/util/DHISConnectorUtil.java
@@ -1,0 +1,66 @@
+package org.openmrs.module.dhisconnector.api.util;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+public class DHISConnectorUtil {
+
+    public static String zipMappingBundle (String tempDirectory, List<File> fileList) throws IOException {
+        String path = tempDirectory + "mappingBundle_" + (new Date()).getTime() + ".zip";
+        FileOutputStream fOut = new FileOutputStream(path);
+        ZipOutputStream zOut = new ZipOutputStream(fOut);
+        for (File file: fileList) {
+            FileInputStream fis = new FileInputStream(file);
+            ZipEntry zipEntry = new ZipEntry(file.getName());
+            zOut.putNextEntry(zipEntry);
+
+            byte[] bytes = new byte[1024];
+            int length;
+            while ((length = fis.read(bytes)) >= 0) {
+                zOut.write(bytes, 0 , length);
+            }
+            fis.close();
+        }
+        zOut.close();
+        fOut.close();
+        return path;
+    }
+
+    public static  List<File> unzipMappingBundle (ZipFile zipFile, String tempDirectory) throws IOException {
+        List<File> files = new ArrayList<>();
+        for (Enumeration<? extends ZipEntry> e = zipFile.entries(); e.hasMoreElements();) {
+            ZipEntry zipEntry = e.nextElement();
+            File output = new File(tempDirectory + zipEntry.getName());
+            if (!output.exists()) {
+                output.getParentFile().mkdirs();
+                output.createNewFile();
+            }
+            BufferedInputStream inputStream = new BufferedInputStream(zipFile.getInputStream(zipEntry));
+            BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(output));
+            IOUtils.copy(inputStream, outputStream);
+            outputStream.close();
+            inputStream.close();
+            files.add(output);
+        }
+        return files;
+    }
+
+    public static boolean doesMappingInclude (File[] filesList, String mapping) {
+        for (File file: filesList) {
+            System.out.println("file name = " + file.getName());
+            System.out.println("mapping name = " + mapping);
+            if (file.getName().equals(mapping)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
+++ b/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
@@ -168,12 +168,12 @@ public class DHISConnectorController {
 
 	@RequestMapping(value = "/module/dhisconnector/uploadMapping", method = RequestMethod.POST)
 	public void uploadMapping(ModelMap model,
-			@RequestParam(value = "mapping", required = false) MultipartFile mapping) {
+			@RequestParam(value = "mapping", required = false) MultipartFile mapping) throws IOException {
 		String successMessage = "";
 		String failedMessage = "";
 
 		if (!mapping.isEmpty()) {
-			String msg = Context.getService(DHISConnectorService.class).uploadMappings(mapping);
+			String msg = Context.getService(DHISConnectorService.class).importMappingBundle(mapping);
 
 			if (msg.startsWith("Successfully")) {
 				successMessage = msg;
@@ -213,7 +213,7 @@ public class DHISConnectorController {
 		if (selectedMappings != null) {
 			try {
 				String[] exported = Context.getService(DHISConnectorService.class)
-						.exportSelectedMappings(selectedMappings);
+						.exportMapping(selectedMappings);
 				msg = exported[0];
 				int BUFFER_SIZE = 4096;
 				String fullPath = exported[1];// contains path to

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,11 @@
             </dependency>
 
             <!-- End OpenMRS core -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>2.12.3</version>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Purpose 
fix [[DCM-51] Implement sharing DHIS mappings with metadata function](https://issues.openmrs.org/browse/DCM-51)

## Approach
Include related metadata as XML files into the export bundle
Save imported metadata as serialized objects
Write unit tests to test mapping sharing
Create a new file to keep utility functions of the DHISService file

## Environment 
- Java 8 Oracle
- Maven 3.6.3
- OpenMRS Reference Application 2.11.0
- MySQL server 
- macOS bigSur