### PR TITLE
DCM 59: Implement export DHIS mappings with underlying metadata feature

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -99,6 +99,11 @@
 
         <!-- End OpenMRS core -->
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+
 		<!-- https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple -->
 		<dependency>
 		    <groupId>com.googlecode.json-simple</groupId>

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/DHISConnectorService.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/DHISConnectorService.java
@@ -11,6 +11,7 @@
  */
 package org.openmrs.module.dhisconnector.api;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -75,8 +76,8 @@ public interface DHISConnectorService extends OpenmrsService {
 
 	public String uploadMappings(MultipartFile mapping);
 	
-	public String[] exportSelectedMappings(String[] selectedMappings);
-	
+	public String[] exportMappings(String[] selectedMappings) throws IOException;
+
 	public boolean dhis2BackupExists();
 	
 	public String getLastSyncedAt();

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/db/DHISConnectorDAO.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/db/DHISConnectorDAO.java
@@ -16,6 +16,7 @@ package org.openmrs.module.dhisconnector.api.db;
 import java.util.List;
 
 import org.openmrs.Location;
+import org.openmrs.api.db.SerializedObject;
 import org.openmrs.module.dhisconnector.LocationToOrgUnitMapping;
 import org.openmrs.module.dhisconnector.ReportToDataSetMapping;
 
@@ -43,4 +44,6 @@ public interface DHISConnectorDAO {
 	void saveLocationToOrgUnitMapping(LocationToOrgUnitMapping locationToOrgUnitMapping);
 
 	void deleteLocationToOrgUnitMappingsByLocation(Location location);
+
+	SerializedObject getSerializedObjectByUuid(String uuid);
 }

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/db/hibernate/HibernateDHISConnectorDAO.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/db/hibernate/HibernateDHISConnectorDAO.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.Location;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.db.SerializedObject;
 import org.openmrs.api.db.hibernate.DbSessionFactory;
 import org.openmrs.module.dhisconnector.LocationToOrgUnitMapping;
 import org.openmrs.module.dhisconnector.ReportToDataSetMapping;
@@ -123,5 +124,13 @@ public class HibernateDHISConnectorDAO implements DHISConnectorDAO {
 		sessionFactory.getCurrentSession()
 				.createQuery("delete from LocationToOrgUnitMapping r where r.location = :location")
 				.setParameter("location", location).executeUpdate();
+	}
+
+	@Override
+	public SerializedObject getSerializedObjectByUuid(String uuid) {
+		SerializedObject serializedObject = (SerializedObject) sessionFactory.getCurrentSession()
+				.createQuery("from SerializedObject s where s.uuid = :uuid")
+				.setParameter("uuid", uuid).uniqueResult();
+		return serializedObject;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/util/DHISConnectorUtil.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/util/DHISConnectorUtil.java
@@ -1,0 +1,70 @@
+package org.openmrs.module.dhisconnector.api.util;
+
+import org.apache.commons.io.IOUtils;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.db.SerializedObject;
+import org.openmrs.module.dhisconnector.api.db.DHISConnectorDAO;
+import org.openmrs.module.dhisconnector.api.db.hibernate.HibernateDHISConnectorDAO;
+import org.openmrs.module.dhisconnector.api.model.DHISMapping;
+import org.openmrs.module.reporting.cohort.definition.CohortDefinition;
+import org.openmrs.module.reporting.dataset.definition.CohortIndicatorDataSetDefinition;
+import org.openmrs.module.reporting.dataset.definition.DataSetDefinition;
+import org.openmrs.module.reporting.evaluation.parameter.Mapped;
+import org.openmrs.module.reporting.indicator.CohortIndicator;
+import org.openmrs.module.reporting.indicator.dimension.CohortDefinitionDimension;
+import org.openmrs.module.reporting.report.definition.PeriodIndicatorReportDefinition;
+import org.openmrs.module.reporting.report.definition.service.ReportDefinitionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class DHISConnectorUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(DHISConnectorUtil.class);
+
+    public static String zipMappingBundle (String tempDirectory, List<File> fileList) {
+        String path = tempDirectory + "mappingBundle_" + (new Date()).getTime() + ".zip";
+        ZipOutputStream zOut = null;
+        FileInputStream fis = null;
+        try (FileOutputStream fOut = new FileOutputStream(path)) {
+            zOut = new ZipOutputStream(fOut);
+            for (File file : fileList) {
+                fis = new FileInputStream(file);
+                ZipEntry zipEntry = new ZipEntry(file.getName());
+                zOut.putNextEntry(zipEntry);
+
+                byte[] bytes = new byte[1024];
+                int length;
+                while ((length = fis.read(bytes)) >= 0) {
+                    zOut.write(bytes, 0, length);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            IOUtils.closeQuietly(fis);
+            IOUtils.closeQuietly(zOut);
+        }
+        return path;
+    }
+
+    public static boolean mappingExists(File[] filesList, String mapping) {
+        log.info("Searching for the correct mapping");
+        log.debug("Mapping: " + mapping);
+        for (File file: filesList) {
+            log.debug("File name: " + file.getName());
+            if (file.getName().equals(mapping)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
+++ b/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
@@ -213,7 +213,7 @@ public class DHISConnectorController {
 		if (selectedMappings != null) {
 			try {
 				String[] exported = Context.getService(DHISConnectorService.class)
-						.exportSelectedMappings(selectedMappings);
+						.exportMappings(selectedMappings);
 				msg = exported[0];
 				int BUFFER_SIZE = 4096;
 				String fullPath = exported[1];// contains path to

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,13 @@
 
             <!-- End OpenMRS core -->
 
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>2.12.3</version>
+                <scope>compile</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
### Purpose

fix the ticket [[DCM-59] Implement export DHIS mapping files with the underlying metadata feature](https://issues.openmrs.org/browse/DCM-59)

### Approach

Include related metadata as XML files into the export bundle
Write unit tests to test mapping sharing
Create a new file to keep utility functions of the DHISService file

### Environment

- Java 8 Oracle
- Maven 3.6.3
- OpenMRS Reference Application 2.11.0
- MySQL server
- macOS bigSur