### PR TITLE
DCM 63: Improve the export mappings function to let users pick metadata export

### DIFF
--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/DHISConnectorService.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/DHISConnectorService.java
@@ -76,7 +76,7 @@ public interface DHISConnectorService extends OpenmrsService {
 
 	public String importMappings(MultipartFile mapping) throws IOException;
 	
-	public String[] exportMappings(String[] selectedMappings) throws IOException;
+	public String[] exportMappings(String[] selectedMappings, boolean shouldIncludeMetadata) throws IOException;
 
 	public boolean dhis2BackupExists();
 	

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/impl/DHISConnectorServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/impl/DHISConnectorServiceImpl.java
@@ -884,7 +884,7 @@ public class DHISConnectorServiceImpl extends BaseOpenmrsService implements DHIS
 	}
 
 	@Override
-	public String[] exportMappings(String[] mappings) throws IOException {
+	public String[] exportMappings(String[] mappings, boolean shouldIncludeMetadata) throws IOException {
 		String sourceDirectory = OpenmrsUtil.getApplicationDataDirectory() + DHISCONNECTOR_MAPPINGS_FOLDER + File.separator;
 		String tempDirectory = OpenmrsUtil.getApplicationDataDirectory() + DHISCONNECTOR_TEMP_FOLDER + File.separator;
 		(new File(tempDirectory)).mkdirs();
@@ -908,8 +908,10 @@ public class DHISConnectorServiceImpl extends BaseOpenmrsService implements DHIS
 				File mappingFile = new File(mappingPath);
 				fileList.add(mappingFile);
 				// Extract and store related metadata in the metadataSet
-				Set<SerializedObject> extractedMetadata = extractMetadataFromMapping(mappingPath);
-				metadataSet.addAll(extractedMetadata);
+				if (shouldIncludeMetadata) {
+					Set<SerializedObject> extractedMetadata = extractMetadataFromMapping(mappingPath);
+					metadataSet.addAll(extractedMetadata);
+				}
 			} else {
 				log.error("The requested mapping doesn't exist: " + mapping);
 			}

--- a/api/src/test/java/org/openmrs/module/dhisconnector/api/DHISConnectorServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/dhisconnector/api/DHISConnectorServiceTest.java
@@ -182,7 +182,7 @@ public class DHISConnectorServiceTest extends BaseModuleContextSensitiveTest {
 		dhisConnectorService.saveMapping(mapping);
 
 		String[] pathToBundle =
-				dhisConnectorService.exportMappings(new String[]{"mapping-test-unit." + mapping.getCreated()});
+				dhisConnectorService.exportMappings(new String[]{"mapping-test-unit." + mapping.getCreated()}, true);
 		Assert.assertEquals("Successfully bundled the mapping with the metadata", pathToBundle[0]);
 	}
 
@@ -203,7 +203,7 @@ public class DHISConnectorServiceTest extends BaseModuleContextSensitiveTest {
 		dhisConnectorService.saveMapping(mapping);
 
 		String[] pathToBundle =
-				dhisConnectorService.exportMappings(new String[]{"mapping-test-unit." + mapping.getCreated()});
+				dhisConnectorService.exportMappings(new String[]{"mapping-test-unit." + mapping.getCreated()}, true);
 		Assert.assertEquals("Successfully bundled the mapping with the metadata", pathToBundle[0]);
 
 		dhisConnectorService.permanentlyDeleteMapping(mapping);

--- a/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
+++ b/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
@@ -32,7 +32,6 @@ import org.apache.commons.logging.LogFactory;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.json.simple.JSONObject;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Location;
 import org.openmrs.api.AdministrationService;
@@ -178,6 +177,11 @@ public class DHISConnectorController {
 
 	@RequestMapping(value = "/module/dhisconnector/exportMappings", method = RequestMethod.POST)
 	public void exportMapping(ModelMap model, HttpServletRequest request, HttpServletResponse response) {
+		boolean shouldIncludeMetadata = true;
+		String dontIncludeParameter = request.getParameter("dontIncludeMetadata");
+		if (dontIncludeParameter != null) {
+			shouldIncludeMetadata = !dontIncludeParameter.equals("on");
+		}
 		String[] selectedMappings = request.getParameter("selectedMappings") != null
 				? request.getParameter("selectedMappings").split("<:::>") : null;
 		String msg = "";
@@ -185,7 +189,7 @@ public class DHISConnectorController {
 		if (selectedMappings != null) {
 			try {
 				String[] exported = Context.getService(DHISConnectorService.class)
-						.exportMappings(selectedMappings);
+						.exportMappings(selectedMappings, shouldIncludeMetadata);
 				msg = exported[0];
 				int BUFFER_SIZE = 4096;
 				String fullPath = exported[1];// contains path to

--- a/omod/src/main/webapp/manageMappings.jsp
+++ b/omod/src/main/webapp/manageMappings.jsp
@@ -33,13 +33,15 @@
 	<div class="box">
 		<table>
 			<tr>
-				<th><label><input id="checkAll" type="checkbox" ng-click="toggleAddAllToExportSelected(existingMappings)" ng-model="selectAllMappings"><openmrs:message code="general.select" /></label></th>
+				<th>
+					<input id="checkAll" type="checkbox" ng-click="toggleAddAllToExportSelected(existingMappings)" ng-model="selectAllMappings">
+				</th>
 				<th><openmrs:message code="general.name"/></th>
 				<th><openmrs:message code="dhisconnector.manageMappings.createdOn" /></th>
 				<th style="float: right;"><openmrs:message code="general.action" /></th>
 			</tr>
 			<tr ng-repeat="mapping in existingMappings track by $index" title="<openmrs:message code='dhisconnector.manageMappings.clickToEdit'/> {{mapping.name}}" ng-click="loadMappingEditor(fetchMappingDisplay(mapping))" class="mapping-tr">
-				<td>
+				<td style="padding-left: 4px">
 					<input
 							id="{{mapping.name}}"
 							type="checkbox"
@@ -57,17 +59,25 @@
 				</td>
 			</tr>
 		</table>
-		<div class="margin-top">
-			<form class="inline-block" method="POST" action="exportMappings.form">
-				<input type="hidden" value="" name="selectedMappings" id="selected-mappings-to-export">
-				<input ng-disabled="disableMultipleActions()" type="submit" value='Export Selected'>
-			</form>
-			<input
-					type="button"
-					class="inline-block"
-					value="<openmrs:message code='dhisconnector.manageMappings.deleteSelected'/>"
-					ng-disabled="disableMultipleActions()"
-					ng-click="deleteSelectedMappings()">
+		<div class="margin-top mappings-multiple-actions-grid">
+			<div>
+				<input
+						type="button"
+						value="<openmrs:message code='dhisconnector.manageMappings.deleteSelected'/>"
+						ng-disabled="disableMultipleActions()"
+						ng-click="deleteSelectedMappings()">
+			</div>
+			<div>
+				<form method="POST" action="exportMappings.form">
+					<input type="hidden" value="" name="selectedMappings" id="selected-mappings-to-export">
+					<input ng-disabled="disableMultipleActions()" type="submit" value='Export Selected'>
+					<br>
+					<label ng-hide="disableMultipleActions()">
+						<input type="checkbox" name="dontIncludeMetadata">
+						<span style="font-size: smaller">Do not include report metadata</span>
+					</label>
+				</form>
+			</div>
 		</div>
 	</div>
 </div>

--- a/omod/src/main/webapp/resources/dhisconnector.css
+++ b/omod/src/main/webapp/resources/dhisconnector.css
@@ -90,3 +90,8 @@ table, th, td {
 .inline-block {
     display: inline-block;
 }
+
+.mappings-multiple-actions-grid {
+    display: grid;
+    grid-template-columns: 100px 300px;
+}


### PR DESCRIPTION
### Purpose

fix the ticket [[DCM-63] Improve the export mappings function to let users pick metadata export](https://issues.openmrs.org/browse/DCM-63)

### Approach

- Change the form to have a checkbox to pick if the metadata are not required 
- Catch the value from the controller and modify the service function to get a boolean as a parameter 
- Check for the parameter value before adding the metadata into the bundle

### Screenshot 
![image](https://user-images.githubusercontent.com/45477334/128591246-78bfe22e-ec6e-4b87-9a4b-daa8e06b9f69.png)


### Demo

https://user-images.githubusercontent.com/45477334/128591305-a4f60d05-8f30-4902-a31e-7650c2bdf3a3.mov



### Environment

- Java 8 Oracle
- Maven 3.6.3
- OpenMRS Reference Application 2.11.0
- MySQL server
- macOS bigSur