### PR TITLE
DCM-7: Make the enable automation option a separate option

### DIFF
--- a/api/src/main/java/org/openmrs/module/dhisconnector/Configurations.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/Configurations.java
@@ -32,7 +32,7 @@ public class Configurations {
 		return "true".equals(Context.getAdministrationService().getGlobalProperty(TOGGLE_AUTOMATION));
 	}
 	
-	public void toogleAutomation(boolean onOrOff) {
+	public void toggleAutomation(boolean onOrOff) {
 		GlobalProperty gp = Context.getAdministrationService().getGlobalPropertyObject(TOGGLE_AUTOMATION);
 		
 		gp.setPropertyValue(Boolean.toString(onOrOff));

--- a/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
+++ b/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
@@ -382,18 +382,13 @@ public class DHISConnectorController {
 		model.addAttribute("showLogin", (Context.getAuthenticatedUser() == null) ? true : false);
 	}
 
-	@RequestMapping(value = "/module/dhisconnector/automation", method = RequestMethod.POST)
+	@RequestMapping(value = "/module/dhisconnector/automation", params = "submit", method = RequestMethod.POST)
 	public void postAutomationPage(ModelMap model, HttpServletRequest request) {
 		String response = "";
 		String mapping = request.getParameter("mapping");
 		Configurations configs = new Configurations();
 		List<String> postResponse = new ArrayList<String>();
 		List<String> toBeRan = new ArrayList<String>();
-
-		if (request.getParameter("toogleAutomation") != null)
-			configs.toogleAutomation(true);
-		else
-			configs.toogleAutomation(false);
 
 		if (request.getParameterValues("mappingIds") != null) {
 			for (String s : request.getParameterValues("mappingIds")) {
@@ -443,6 +438,24 @@ public class DHISConnectorController {
 		}
 
 		initialiseAutomation(model, configs.automationEnabled(), postResponse);
+		if (StringUtils.isNotBlank(response))
+			request.getSession().setAttribute(WebConstants.OPENMRS_MSG_ATTR, response);
+	}
+
+	@RequestMapping(value = "/module/dhisconnector/automation", params = "saveAutomationToggle", method = RequestMethod.POST)
+	public void toggleAutomation(ModelMap model, HttpServletRequest request) {
+		String response = "";
+		Configurations configs = new Configurations();
+
+		if (request.getParameter("toggleAutomation") != null) {
+			configs.toggleAutomation(true);
+			response += " -> Successfully turned on automation";
+		} else {
+			configs.toggleAutomation(false);
+			response += " -> Successfully turned off automation";
+		}
+
+		initialiseAutomation(model, configs.automationEnabled(), new ArrayList<String>());
 		if (StringUtils.isNotBlank(response))
 			request.getSession().setAttribute(WebConstants.OPENMRS_MSG_ATTR, response);
 	}

--- a/omod/src/main/webapp/automation.jsp
+++ b/omod/src/main/webapp/automation.jsp
@@ -14,10 +14,13 @@
 <spring:message code="dhisconnector.automation.description"/>
 <form method="post">
 	<br />
-    <input type="checkbox" name="toogleAutomation" <c:if test="${automationEnabled}">checked="checked"</c:if>
+    <input type="checkbox" name="toggleAutomation" <c:if test="${automationEnabled}">checked="checked"</c:if>
            <openmrs:hasPrivilege privilege="Manage Automation" inverse="true">disabled</openmrs:hasPrivilege>>
         <spring:message code="dhisconnector.automation.toggleAutomation"/>
     </input>
+    <openmrs:hasPrivilege privilege="Manage Automation">
+        <input name="saveAutomationToggle" type="submit" value="<spring:message code="dhisconnector.save" />"/>
+    </openmrs:hasPrivilege>
     <br />
     <br />
     <spring:message code="dhisconnector.automation.periodTypeMessage"/>
@@ -72,7 +75,7 @@
         </tbody>
     </table>
     <openmrs:hasPrivilege privilege="Run Automation,Manage Automation">
-        <input type="submit" value="<spring:message code='dhisconnector.automation.submit'/>">
+        <input name="submit" type="submit" value="<spring:message code='dhisconnector.automation.submit'/>">
     </openmrs:hasPrivilege>
 </form>
 


### PR DESCRIPTION
## The issue I worked on
See [https://issues.openmrs.org/browse/DCM-7](https://issues.openmrs.org/browse/DCM-7) 

## Description of what I changed:
Made the enable automation option of automation page a separate option. So the users have a separate button to toggle automation

## Related Thread and Preview:
https://vimeo.com/584612376
