### PR TITLE
DCM-64: Improve the import mappings function to include override metadata option

### DIFF
--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/DHISConnectorService.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/DHISConnectorService.java
@@ -74,7 +74,7 @@ public interface DHISConnectorService extends OpenmrsService {
 
 	public DHISDataSet getDHISDataSetById(String id);
 
-	public String importMappings(MultipartFile mapping) throws IOException;
+	public String importMappings(MultipartFile mapping, boolean shouldReplaceMetadata) throws IOException;
 	
 	public String[] exportMappings(String[] selectedMappings) throws IOException;
 

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/db/DHISConnectorDAO.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/db/DHISConnectorDAO.java
@@ -48,4 +48,6 @@ public interface DHISConnectorDAO {
 	SerializedObject getSerializedObjectByUuid(String uuid);
 
 	void saveSerializedObject(SerializedObject serializedObject);
+
+	void deleteSerializedObjectByUuid(String uuid);
 }

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/db/hibernate/HibernateDHISConnectorDAO.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/db/hibernate/HibernateDHISConnectorDAO.java
@@ -138,4 +138,11 @@ public class HibernateDHISConnectorDAO implements DHISConnectorDAO {
 				.setParameter("uuid", uuid).uniqueResult();
 		return serializedObject;
 	}
+
+	@Override
+	public void deleteSerializedObjectByUuid(String uuid) {
+		sessionFactory.getCurrentSession()
+				.createQuery("delete from SerializedObject s where s.uuid = :uuid")
+				.setParameter("uuid", uuid).executeUpdate();
+	}
 }

--- a/api/src/main/java/org/openmrs/module/dhisconnector/api/impl/DHISConnectorServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/dhisconnector/api/impl/DHISConnectorServiceImpl.java
@@ -838,7 +838,7 @@ public class DHISConnectorServiceImpl extends BaseOpenmrsService implements DHIS
 	}
 	
 	@Override
-	public String importMappings (MultipartFile mappingBundle) throws IOException {
+	public String importMappings (MultipartFile mappingBundle, boolean shouldReplaceMetadata) throws IOException {
 		String sourceDirectory = OpenmrsUtil.getApplicationDataDirectory() + DHISCONNECTOR_MAPPINGS_FOLDER + File.separator;
 		String tempDirectory = OpenmrsUtil.getApplicationDataDirectory() + DHISCONNECTOR_TEMP_FOLDER + File.separator;
 		(new File(sourceDirectory)).mkdirs();
@@ -864,8 +864,13 @@ public class DHISConnectorServiceImpl extends BaseOpenmrsService implements DHIS
 					// Check if the system already has an object with the same uuid
 					SerializedObject existing = dao.getSerializedObjectByUuid(serializedObject.getUuid());
 					if (existing != null) {
-						log.info(serializedObject.getName() + " already exists in the system. Ignored");
-						continue;
+						if (shouldReplaceMetadata) {
+							log.info("Overriding the existing object with the newly imported object");
+							dao.deleteSerializedObjectByUuid(serializedObject.getUuid());
+						} else {
+							log.info(serializedObject.getName() + " already exists in the system. Ignored");
+							continue;
+						}
 					}
 					// Set serialized object creator to the current user and date created to the current day
 					serializedObject.setCreator(Context.getAuthenticatedUser());

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -59,6 +59,7 @@ ${project.parent.artifactId}.dhis2backup.failure=Something went wrong, please ch
 ${project.parent.artifactId}.dhis2backup.wrongUpload=Selected DHIS2 API Backup can't be empty and must be a zip file
 ${project.parent.artifactId}.dhis2backup.replaceSuccess=Successfully replaced DHIS2 API backup
 ${project.parent.artifactId}.dhis2backup.import.success=Successfully uploaded/imported DHIS2 API backup
+${project.parent.artifactId}.manageMappings.overrideLabel=Override metadata with matching uuids
 ${project.parent.artifactId}.manageMappings.addNew=Add New Mapping
 ${project.parent.artifactId}.manageMappings.existingMappings=Existing Mappings
 ${project.parent.artifactId}.manageMappings.createdOn=Created On

--- a/api/src/test/java/org/openmrs/module/dhisconnector/api/DHISConnectorServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/dhisconnector/api/DHISConnectorServiceTest.java
@@ -212,7 +212,8 @@ public class DHISConnectorServiceTest extends BaseModuleContextSensitiveTest {
 		File file = new File(pathToBundle[1]);
 		MultipartFile multipartFile =
 				new MockMultipartFile(file.getName(), file.getName(), "zip", Files.readAllBytes(file.toPath()));
-		Assert.assertEquals("Successfully imported the mapping files", dhisConnectorService.importMappings(multipartFile));
+		Assert.assertEquals("Successfully imported the mapping files",
+				dhisConnectorService.importMappings(multipartFile, false));
 		Assert.assertNotNull(dhisConnectorService.getMapping("mapping-test-unit." + mapping.getCreated()));
 		Assert.assertNotNull(reportDefinitionService.getDefinitionByUuid(PIR_UUID));
 	}

--- a/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
+++ b/omod/src/main/java/org/openmrs/module/dhisconnector/web/controller/DHISConnectorController.java
@@ -305,12 +305,13 @@ public class DHISConnectorController {
 	}
 
 	@RequestMapping(value = "/module/dhisconnector/manageMappings", method = RequestMethod.POST)
-	public void manageMappings(ModelMap model, @RequestParam(value = "mapping", required = false) MultipartFile mapping) throws IOException {
+	public void manageMappings(ModelMap model, @RequestParam(value = "mapping", required = false) MultipartFile mapping,
+							   @RequestParam(value = "shouldReplaceMetadata", required = false) boolean shouldReplaceMetadata) throws IOException {
 		String successMessage = "";
 		String failedMessage = "";
 
 		if (!mapping.isEmpty()) {
-			String msg = Context.getService(DHISConnectorService.class).importMappings(mapping);
+			String msg = Context.getService(DHISConnectorService.class).importMappings(mapping, shouldReplaceMetadata);
 
 			if (msg.startsWith("Successfully")) {
 				successMessage = msg;

--- a/omod/src/main/webapp/manageMappings.jsp
+++ b/omod/src/main/webapp/manageMappings.jsp
@@ -27,6 +27,13 @@
 	<form method="POST" enctype="multipart/form-data">
 		<input type="file" name="mapping">
 		<input type="submit" value='<spring:message code="dhisconnector.upload"/>'>
+		<br />
+		<label style="margin-top: 2rem;">
+			<input type="checkbox" value="on" name="shouldReplaceMetadata">
+			<span style="font-size: smaller">
+				<openmrs:message code="dhisconnector.manageMappings.overrideLabel"/>
+			</span>
+		</label>
 	</form>
 </div>
 


### PR DESCRIPTION
### Purpose

fix the ticket [[DCM-64] Improve the import mappings function to include override metadata option](https://issues.openmrs.org/browse/DCM-64)

### Approach

- Change the form to have a checkbox to check if the metadata needs to be overridden
- Catch the value from the controller and modify the service function to get a boolean as a parameter 
- Check for the parameter value and if true replace the existing otherwise ignore

### Screenshot 

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/45477334/129008255-22ec5159-8516-446c-ae60-c7de5bc707dc.png">

### Demo

https://user-images.githubusercontent.com/45477334/129008380-556ce474-357e-4056-92de-8552c408b3cc.mov


### Environment

- Java 8 Oracle
- Maven 3.6.3
- OpenMRS Reference Application 2.11.0
- MySQL server
- macOS bigSur