### PR TITLE
DCM-73: Improve Run Report UI getting cluttered after pushing data

### DIFF
--- a/omod/src/main/webapp/resources/dhisconnector.css
+++ b/omod/src/main/webapp/resources/dhisconnector.css
@@ -95,3 +95,7 @@ table, th, td {
     display: grid;
     grid-template-columns: 100px 300px;
 }
+
+.max-content-size {
+    width: max-content;
+}

--- a/omod/src/main/webapp/runReports.jsp
+++ b/omod/src/main/webapp/runReports.jsp
@@ -37,7 +37,7 @@
     </tr>
     <tr>
       <td>
-        <div id="locationsList">Select a Mapping to choose the Locations</div>
+        <div id="locationsList" class="max-content-size">Select a Mapping to choose the Locations</div>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
## The issue I worked on 
See: [DCM-73 Run Report UI is getting cluttered after pushing data](https://issues.openmrs.org/browse/DCM-73)

## Description of what I changed: 
Fixed the issues where UI gets cluttered after multiple organization responses are displayed.

### Issue
![issue](https://user-images.githubusercontent.com/27495258/139644086-94f10616-11de-472e-8b31-a415835b2674.png)

### After fixing the issue
![after](https://user-images.githubusercontent.com/27495258/139646377-33fe5547-5d37-43aa-9cb2-3fc7109958b3.png)


